### PR TITLE
fix: incorrect pagination info in response when using search

### DIFF
--- a/internal/domain/password/usecase/usecase.go
+++ b/internal/domain/password/usecase/usecase.go
@@ -35,7 +35,7 @@ type useCase struct {
 
 func (u *useCase) IndexPassword(ctx context.Context, req password.Request) (*password.IndexResponse[password.Response], error) {
 	// set up repo options
-	opts := []repo.Options{repo.Paginate(&req.M), repo.Order(req.Order + " " + req.Sort)}
+	opts := []repo.Options{repo.Order(req.Order + " " + req.Sort)}
 	// additionally add search option
 	if req.Search != "" {
 		q := "username ILIKE '%" + req.Search + "%'" // search in password
@@ -54,6 +54,8 @@ func (u *useCase) IndexPassword(ctx context.Context, req password.Request) (*pas
 			opts = append(opts, repo.Ors(q2))
 		}
 	}
+	// set up pagination in last order
+	opts = append(opts, repo.Paginate(&req.M))
 
 	// search for all passwords that matched given conditions
 	pws, err := u.repo.FindPassword(ctx, opts...)


### PR DESCRIPTION
incorrect pagination info in response when using `search` query param, so put the pagination option in the last part of all available options, so that setup pagination done after all query was run
example of response
```json
{
  "status": "SUCCESS",
  "data": [
    {
      "id": 1,
      "username": "user1",
      "category_id": 1
    },
    {
      "id": 18,
      "username": "user2",
      "category_id": 1
    },
    {
      "id": 50,
      "username": "user3",
      "category_id": 1
    },
    {
      "id": 55,
      "username": "user4",
      "category_id": 1
    }
  ],
  "meta": {
    "per_page": 6,
    "current_page": 1,
    "next_page": 2,
    "total_page": 9
  }
}
```
expected result
```json
{
  "status": "SUCCESS",
  "data": [
    {
      "id": 1,
      "username": "user1",
      "category_id": 1
    },
    {
      "id": 18,
      "username": "user2",
      "category_id": 1
    },
    {
      "id": 50,
      "username": "user3",
      "category_id": 1
    },
    {
      "id": 55,
      "username": "user4",
      "category_id": 1
    }
  ],
  "meta": {
    "per_page": 6,
    "current_page": 1,
    "total_page": 1
  }
}
```